### PR TITLE
immediately return instead of declaring a local variable

### DIFF
--- a/src/main/java/com/izerofx/framework/basic/common/controller/BaseController.java
+++ b/src/main/java/com/izerofx/framework/basic/common/controller/BaseController.java
@@ -60,8 +60,7 @@ public abstract class BaseController {
         }
         pageNo = pageNo == 0 ? 0 : pageNo - 1;
         pageSize = pageSize == 0 ? 10 : pageSize;
-        Pageable page = new PageRequest(pageNo, pageSize);
-        return page;
+        return new PageRequest(pageNo, pageSize);
     }
 
     /**


### PR DESCRIPTION
@qjx378  hello, I have used your project, and want do some contribution to improve the Code Quality for your project with Sonarqube.
This PR is that Local Variables should not be declared and then immediately returned or thrown. Declaring a variable only to immediately return or throw it is a bad practice.
[https://rules.sonarsource.com/java/RSPEC-1488](url)